### PR TITLE
Remove blank line at the start from init file

### DIFF
--- a/debian/softether-vpnserver.init
+++ b/debian/softether-vpnserver.init
@@ -1,4 +1,3 @@
-
 #! /bin/sh
 
 ### BEGIN INIT INFO


### PR DESCRIPTION
There was a blank line at the start of the file before #! /bin/sh, which declares which interpeter it has to use. With this blank line the init script will not work and will throw error "exit status 1", meaning the deamon doesn't start.

This simple edit to the file will fix that
https://github.com/SoftEtherVPN/SoftEtherVPN/issues/276 merge